### PR TITLE
Find the PowerPC compilers, on RedHat/Fedora

### DIFF
--- a/kernel/Mk/Makeconf
+++ b/kernel/Mk/Makeconf
@@ -71,7 +71,7 @@ else
 TOOLPREFIX?=	$(patsubst %gcc,%,$(firstword $(shell type -p \
 			$(ARCH)-gcc $(ARCH)-linux-gcc $(ARCH)-unknown-elf-gcc \
 			$(ARCH)-elf-gcc $(ARCH)-unknown-linux-gnu-gcc \
-			$(ARCH)-linux-gnu-gcc $(ARCH)-pc-linux-gnu-gcc)))
+			$(ARCH)-linux-gnu-gcc $(ARCH)-pc-linux-gnu-gcc $(ARCH)-redhat-linux-gcc)))
 
 endif
 


### PR DESCRIPTION
Upstream patch from the Orion project. 

On Fedora/PPC64, the default GCC suffix differs, so we can't find the toolchain, and the build system thinks we're building on an x86 host (which predictably fails), so update the TOOLPREFIX, for the kernel.